### PR TITLE
Doctrine page

### DIFF
--- a/doctrine.html
+++ b/doctrine.html
@@ -57,12 +57,12 @@
 		<div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
-			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapsePhaseOne" aria-expanded="true" aria-controls="collapsePhaseOne">
 			<span class="caret"></span> Phase 1: Stop self-harm
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapsePhaseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
 		      <p class="lead">What doctrine does your organization make use of?</p>
 		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
@@ -160,12 +160,12 @@
 			    <div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
-			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapsePhaseTwo" aria-expanded="true" aria-controls="collapsePhaseTwo">
 			<span class="caret"></span> Phase 2: Becoming more context aware
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapsePhaseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
 		      <p class="lead">What doctrine does your organization make use of?</p>
 		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
@@ -263,12 +263,12 @@
 				    <div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
-			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapsePhaseThree" aria-expanded="true" aria-controls="collapsePhaseThree">
 			<span class="caret"></span> Phase 3: Better for less
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapsePhaseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
 		      <p class="lead">What doctrine does your organization make use of?</p>
 		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
@@ -366,12 +366,12 @@
 					    <div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
-			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapsePhaseFour" aria-expanded="true" aria-controls="collapsePhaseFour">
 			<span class="caret"></span> Phase 4: Continuously evolving
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapsePhaseFour" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
 		      <p class="lead">What doctrine does your organization make use of?</p>
 		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>

--- a/doctrine.html
+++ b/doctrine.html
@@ -198,82 +198,31 @@
 			    </thead>
 			    <tbody>
 				<tr>
-				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
-				    <td>Remove bias and duplication</td>
-				</tr>
-				<tr>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
-				</tr>
-				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				  <td class="heading">Operation</td>
 				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
-				</tr>
-				<tr>
 				    <td>Do better with less <em>(continual improvement)</em></td>
 				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
 				    <td></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="2">Structure</td>
+				  <td class="heading">Structure</td>
 				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
+				    <td>Seek the best</td>
+				    <td></td>
+				    <td></td>
 				</tr>
 				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
-				  <td></td>
-				</tr>
-				<tr>
-				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Leading</td>
+				    <td class="heading" rowspan="2">Leading</td>
 				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
 				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
-				</tr>
-				<tr>
 				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
 				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
 				</tr>
 				<tr>
-				  <td>Exploit the landscape</td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				    <td></td>
+				    <td></td>
+				    <td></td>
 				</tr>
 			    </tbody>
 			</table>

--- a/doctrine.html
+++ b/doctrine.html
@@ -244,87 +244,24 @@
 			    <thead>
 				<tr>
 				  <th class="active">Category</th>
-				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				  <th class="active" colspan="2"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
 				</tr>
 			    </thead>
 			    <tbody>
 				<tr>
-				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
-				    <td>Remove bias and duplication</td>
-				</tr>
-				<tr>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
-				</tr>
-				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
-				</tr>
-				<tr>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
-				    <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
-				</tr>
-				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
-				  <td></td>
+				  <td class="heading">Structure</td>
+				    <td>Design for constant evolution</td>
+				    <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				  <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				  <td></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="3">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
-				</tr>
-				<tr>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
-				</tr>
-				<tr>
+				  <td class="heading">Leading</td>
 				  <td>Exploit the landscape</td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
+				  <td>There is no core <em>(everything is transient)</em></td>
 				</tr>
 			    </tbody>
 			</table>

--- a/doctrine.html
+++ b/doctrine.html
@@ -128,80 +128,50 @@
 				<tr>
 				    <td class="heading">Communication</td>
 				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
-				    <td>Remove bias and duplication</td>
-				</tr>
-				<tr>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
-				</tr>
-				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
-				</tr>
-				<tr>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
+				    <td></td>
+				    <td></td>
 				    <td></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="2">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
+				  <td class="heading" rowspan="2">Development</td>
+				  <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				  <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				</tr>
+				<tr>
+				  <td>Use standards where appropriate</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Operation</td>
+				  <td>Manage failure</td>
+				  <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				  <td>Effectiveness over efficiency</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Structure</td>
 				    <td>Think small <em>(as in teams, "two pizza")</em></td>
 				    <td>Distribute power and decision making</td>
 				    <td>Think aptitude and attitude</td>
-				</tr>
-				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
-				  <td></td>
+				    <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				  <td>A bias towards action <em>(learn by playing the game)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="3">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
+				  <td class="heading">Leading</td>
 				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
 				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
-				</tr>
-				<tr>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
-				</tr>
-				<tr>
-				  <td>Exploit the landscape</td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
+				    <td></td>
+				    <td></td>
 				</tr>
 			    </tbody>
 			</table>

--- a/doctrine.html
+++ b/doctrine.html
@@ -34,19 +34,450 @@
 	    <p>Don’t worry if some of the terms are confusing... just use what you can. Like Chess, mapping is a craft and you will get better with practice.</p>
 	    <footer>Simon Wardley in <cite title="Source Title"><a href="https://medium.com/wardleymaps/finding-a-path-cdb1249078c0" target="_blank">Finding a Path</a></cite></footer>
 	</blockquote>
-	    <div class="panel panel-default">
+		<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div class="panel-heading" role="tab" id="headingIntroductionDoctrine">
+			<h4 class="panel-title">
+				<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionDoctrine" aria-expanded="true" aria-controls="collapseIntroduction">
+				<span class="caret"></span> Introduction: What is Doctrine?
+				</a>
+			</h4>
+		</div>
+		<div id="collapseIntroductionDoctrine" class="panel-collapse" role="tabpanel" aria-labelledby="headingIntroductionDoctrine">
+		  <div class="panel-body">
+		    <p class="lead">The doctrine list is simply a list of <strong>universally useful patterns</strong>.</p>
+		    <p>Doctrine is a component of the strategy cycle, as described by <a href="https://twitter.com/swardley">Simon Wardley</a> in <a href="https://medium.com/wardleymaps/on-being-lost-2ef5f05eb1ec">a book on mapping</a>. By examining the doctrine in an organization, you can get an idea of how adaptable it is and how well it will respond to any gameplay. You can do this with your own organization, or with other organizations.</p>
+		    <p>Grab 10-15 people across the organisation (at different levels) and get them to colour the boxes in. Be warned, there'll be lots of arguments but that's not a bad thing.</p>
+		    <p>Once you've assessed the status quo of doctrine in your organization, you can go about fixing it. Simon suggests you do this in phases. The remainder of this page presents his best guess at the order in which you should tackle them.</p>
+		    <p>You can <strong>select cells to highlight them</strong> as you think, discuss, and challenge assumptions. You can <strong>click multiple times to progress through colors</strong> indicating a neutral, weak, warning, and good status.</p>
+		    <p><em>Inspired by and adapted from <a href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley.</em></p>
+		</div>
+		</div>
+		</div>
+		<div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
 			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine
+			<span class="caret"></span> Doctrine: Phase 1
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
 		      <p class="lead">What doctrine does your organization make use of?</p>
 		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
-		      <p><em>Inspired by <a  href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley.</em></p>
+			<table class="table table-hover table-responsive table-rotated-markable">
+			    <thead>
+				<tr>
+				  <th class="active">Category</th>
+				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				</tr>
+			    </thead>
+			    <tbody>
+				<tr>
+				    <td class="heading">Communication</td>
+				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td>Use a common language <em>(necessary for collaboration)</em></td>
+				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Development</td>
+				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td>Focus on user needs</td>
+				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td>Remove bias and duplication</td>
+				</tr>
+				<tr>
+				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td>Use standards where appropriate</td>
+				</tr>
+				<tr>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Operation</td>
+				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td>Think small <em>(as in know the details)</em></td>
+				    <td>Effectiveness over efficiency</td>
+				</tr>
+				<tr>
+				    <td>Do better with less <em>(continual improvement)</em></td>
+				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td>Manage failure</td>
+				    <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Structure</td>
+				    <td>Provide purpose, mastery, & autonomy</td>
+				    <td>Think small <em>(as in teams, "two pizza")</em></td>
+				    <td>Distribute power and decision making</td>
+				    <td>Think aptitude and attitude</td>
+				</tr>
+				<tr>
+				  <td>Design for constant evolution</td>
+				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td>Seek the best</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Learning</td>
+				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td>A bias towards action <em>(learn by playing the game)</em></td>
+				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Leading</td>
+				    <td>Be the owner <em>(take responsibility)</em></td>
+				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td>Think big <em>(inspire others, provide direction)</em></td>
+				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				</tr>
+				<tr>
+				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td>There is no core <em>(everything is transient)</em></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				</tr>
+				<tr>
+				  <td>Exploit the landscape</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+		    </div>
+			    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="doctrineHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<span class="caret"></span> Doctrine: Phase 2
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		    <div class="panel-body">
+		      <p class="lead">What doctrine does your organization make use of?</p>
+		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+			<table class="table table-hover table-responsive table-rotated-markable">
+			    <thead>
+				<tr>
+				  <th class="active">Category</th>
+				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				</tr>
+			    </thead>
+			    <tbody>
+				<tr>
+				    <td class="heading">Communication</td>
+				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td>Use a common language <em>(necessary for collaboration)</em></td>
+				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Development</td>
+				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td>Focus on user needs</td>
+				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td>Remove bias and duplication</td>
+				</tr>
+				<tr>
+				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td>Use standards where appropriate</td>
+				</tr>
+				<tr>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Operation</td>
+				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td>Think small <em>(as in know the details)</em></td>
+				    <td>Effectiveness over efficiency</td>
+				</tr>
+				<tr>
+				    <td>Do better with less <em>(continual improvement)</em></td>
+				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td>Manage failure</td>
+				    <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Structure</td>
+				    <td>Provide purpose, mastery, & autonomy</td>
+				    <td>Think small <em>(as in teams, "two pizza")</em></td>
+				    <td>Distribute power and decision making</td>
+				    <td>Think aptitude and attitude</td>
+				</tr>
+				<tr>
+				  <td>Design for constant evolution</td>
+				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td>Seek the best</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Learning</td>
+				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td>A bias towards action <em>(learn by playing the game)</em></td>
+				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Leading</td>
+				    <td>Be the owner <em>(take responsibility)</em></td>
+				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td>Think big <em>(inspire others, provide direction)</em></td>
+				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				</tr>
+				<tr>
+				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td>There is no core <em>(everything is transient)</em></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				</tr>
+				<tr>
+				  <td>Exploit the landscape</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+			    </div>
+				    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="doctrineHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<span class="caret"></span> Doctrine: Phase 3
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		    <div class="panel-body">
+		      <p class="lead">What doctrine does your organization make use of?</p>
+		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+			<table class="table table-hover table-responsive table-rotated-markable">
+			    <thead>
+				<tr>
+				  <th class="active">Category</th>
+				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				</tr>
+			    </thead>
+			    <tbody>
+				<tr>
+				    <td class="heading">Communication</td>
+				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td>Use a common language <em>(necessary for collaboration)</em></td>
+				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Development</td>
+				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td>Focus on user needs</td>
+				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td>Remove bias and duplication</td>
+				</tr>
+				<tr>
+				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td>Use standards where appropriate</td>
+				</tr>
+				<tr>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Operation</td>
+				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td>Think small <em>(as in know the details)</em></td>
+				    <td>Effectiveness over efficiency</td>
+				</tr>
+				<tr>
+				    <td>Do better with less <em>(continual improvement)</em></td>
+				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td>Manage failure</td>
+				    <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Structure</td>
+				    <td>Provide purpose, mastery, & autonomy</td>
+				    <td>Think small <em>(as in teams, "two pizza")</em></td>
+				    <td>Distribute power and decision making</td>
+				    <td>Think aptitude and attitude</td>
+				</tr>
+				<tr>
+				  <td>Design for constant evolution</td>
+				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td>Seek the best</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Learning</td>
+				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td>A bias towards action <em>(learn by playing the game)</em></td>
+				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Leading</td>
+				    <td>Be the owner <em>(take responsibility)</em></td>
+				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td>Think big <em>(inspire others, provide direction)</em></td>
+				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				</tr>
+				<tr>
+				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td>There is no core <em>(everything is transient)</em></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				</tr>
+				<tr>
+				  <td>Exploit the landscape</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+				    </div>
+					    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="doctrineHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<span class="caret"></span> Doctrine: Phase 4
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		    <div class="panel-body">
+		      <p class="lead">What doctrine does your organization make use of?</p>
+		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+			<table class="table table-hover table-responsive table-rotated-markable">
+			    <thead>
+				<tr>
+				  <th class="active">Category</th>
+				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				</tr>
+			    </thead>
+			    <tbody>
+				<tr>
+				    <td class="heading">Communication</td>
+				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td>Use a common language <em>(necessary for collaboration)</em></td>
+				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Development</td>
+				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td>Focus on user needs</td>
+				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td>Remove bias and duplication</td>
+				</tr>
+				<tr>
+				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td>Use standards where appropriate</td>
+				</tr>
+				<tr>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Operation</td>
+				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td>Think small <em>(as in know the details)</em></td>
+				    <td>Effectiveness over efficiency</td>
+				</tr>
+				<tr>
+				    <td>Do better with less <em>(continual improvement)</em></td>
+				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td>Manage failure</td>
+				    <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Structure</td>
+				    <td>Provide purpose, mastery, & autonomy</td>
+				    <td>Think small <em>(as in teams, "two pizza")</em></td>
+				    <td>Distribute power and decision making</td>
+				    <td>Think aptitude and attitude</td>
+				</tr>
+				<tr>
+				  <td>Design for constant evolution</td>
+				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td>Seek the best</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Learning</td>
+				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td>A bias towards action <em>(learn by playing the game)</em></td>
+				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Leading</td>
+				    <td>Be the owner <em>(take responsibility)</em></td>
+				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td>Think big <em>(inspire others, provide direction)</em></td>
+				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				</tr>
+				<tr>
+				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td>There is no core <em>(everything is transient)</em></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				</tr>
+				<tr>
+				  <td>Exploit the landscape</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+					    </div>
+					    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="doctrineHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<span class="caret"></span> Doctrine: Complete
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		    <div class="panel-body">
+		      <p class="lead">What doctrine does your organization make use of?</p>
+		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
 			<table class="table table-hover table-responsive table-rotated-markable">
 			    <thead>
 				<tr>

--- a/doctrine.html
+++ b/doctrine.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta property="og:title" content="Doctrine" />
+    <meta property="og:description" content="Doctrine. A resource for learning about evolutionary characteristics and applying the concepts in Wardley Mapping." />
+    <meta property="og:image" content="http://evolve.hiredthought.com/images/meta.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:domain" value="evolve.hiredthought.com" />
+    <meta name="twitter:title" value="Doctrine" />
+    <meta name="twitter:description" value="Doctrine. A resource for learning about evolutionary characteristics and applying the concepts in Wardley Mapping." />
+    <meta property="twitter:image" value="http://evolve.hiredthought.com/images/meta.png" />
+    <meta property="twitter:url" value="http://evolve.hiredthought.com" />
+
+    <title>Doctrine</title>
+    <link rel="stylesheet" href="css/style.css">
+    <!--[if IE]>
+	<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+
+    <!-- Twitter Bootstrap: Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="css/bootstrap.min.css">
+
+    <!-- Twitter Bootstrap: Optional theme -->
+    <link rel="stylesheet" href="css/bootstrap-theme.min.css">
+</head>
+
+<body id="home">
+    <div class="container-fluid">
+	<div class="page-header">
+	  <h1>Doctrine <small>What doctrine does your organization make use of?</small></h1>
+	</div>
+	<blockquote>
+	    <p>Don’t worry if some of the terms are confusing... just use what you can. Like Chess, mapping is a craft and you will get better with practice.</p>
+	    <footer>Simon Wardley in <cite title="Source Title"><a href="https://medium.com/wardleymaps/finding-a-path-cdb1249078c0" target="_blank">Finding a Path</a></cite></footer>
+	</blockquote>
+	    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="doctrineHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
+			<span class="caret"></span> Doctrine
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseDoctrine" class="panel-collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		    <div class="panel-body">
+		      <p class="lead">What doctrine does your organization make use of?</p>
+		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+		      <p><em>Inspired by <a  href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley.</em></p>
+			<table class="table table-hover table-responsive table-rotated-markable">
+			    <thead>
+				<tr>
+				  <th class="active">Category</th>
+				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				</tr>
+			    </thead>
+			    <tbody>
+				<tr>
+				    <td class="heading">Communication</td>
+				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td>Use a common language <em>(necessary for collaboration)</em></td>
+				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Development</td>
+				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td>Focus on user needs</td>
+				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td>Remove bias and duplication</td>
+				</tr>
+				<tr>
+				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td>Use standards where appropriate</td>
+				</tr>
+				<tr>
+				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Operation</td>
+				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td>Think small <em>(as in know the details)</em></td>
+				    <td>Effectiveness over efficiency</td>
+				</tr>
+				<tr>
+				    <td>Do better with less <em>(continual improvement)</em></td>
+				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td>Manage failure</td>
+				    <td></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="2">Structure</td>
+				    <td>Provide purpose, mastery, & autonomy</td>
+				    <td>Think small <em>(as in teams, "two pizza")</em></td>
+				    <td>Distribute power and decision making</td>
+				    <td>Think aptitude and attitude</td>
+				</tr>
+				<tr>
+				  <td>Design for constant evolution</td>
+				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td>Seek the best</td>
+				  <td></td>
+				</tr>
+				<tr>
+				  <td class="heading">Learning</td>
+				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td>A bias towards action <em>(learn by playing the game)</em></td>
+				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				</tr>
+				<tr>
+				    <td class="heading" rowspan="3">Leading</td>
+				    <td>Be the owner <em>(take responsibility)</em></td>
+				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td>Think big <em>(inspire others, provide direction)</em></td>
+				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				</tr>
+				<tr>
+				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td>There is no core <em>(everything is transient)</em></td>
+				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				</tr>
+				<tr>
+				  <td>Exploit the landscape</td>
+				  <td></td>
+				  <td></td>
+				  <td></td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+	    </div>
+	</div>
+
+	<p>This work is adapted from <a href="https://medium.com/wardleymaps/finding-a-path-cdb1249078c0" target="_blank">Finding a Path</a> by Simon Wardley, and thereby licensed <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-Share Alike 4.0</a>.</p>
+
+	<a href="https://github.com/bemosior/evolutionary-characteristics" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+    </div>
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="js/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="js/bootstrap.min.js" ></script>
+    <script>
+	window.onload = function(){
+	    $(".table-markable tbody td").on("click", function(e) {
+		if (!$(this).hasClass("heading")) {
+		    $(this).toggleClass("info");
+		}
+	    });
+	    $(".table-rotated-markable tbody td").on("click", function(e) {
+		if (!$(this).hasClass("heading")) {
+		    if($(this).hasClass("danger")) {
+			$(this).toggleClass("danger");
+			$(this).toggleClass("warning");
+		    } else if($(this).hasClass("warning")) {
+			$(this).toggleClass("warning");
+			$(this).toggleClass("success");
+		    } else if($(this).hasClass("success")) {
+			$(this).toggleClass("success");
+		    } else {
+			$(this).toggleClass("danger");
+		    }
+		}
+	    });
+	};
+    </script>
+
+    <script src="https://widget.flowxo.com/embed.js" data-fxo-widget="eyJ0aGVtZSI6IiNmYTgyMjQiLCJ3ZWIiOnsiYm90SWQiOiI1YWY1OTZiODRhNzc1ODAwODBiZDE2MDUiLCJ0aGVtZSI6IiNmYTgyMjQiLCJsYWJlbCI6IkNvbnZlcnNhdGlvbmFsIFdhcmRsZXkgTWFwcGluZyJ9LCJ3ZWxjb21lVGV4dCI6IkN1cmlvdXMgYWJvdXQgV2FyZGxleSBNYXBwaW5nPyJ9" async defer></script>
+	<!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-51537292-5"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-51537292-5');
+    </script>
+</body>
+</html>

--- a/doctrine.html
+++ b/doctrine.html
@@ -50,7 +50,7 @@
 		    <p>Grab 10-15 people across the organisation (at different levels) and get them to colour the boxes in. Be warned, there'll be lots of arguments but that's not a bad thing.</p>
 		    <p>Once you've assessed the status quo of doctrine in your organization, you can go about fixing it. Simon suggests you do this in phases. The remainder of this page presents his best guess at the order in which you should tackle them.</p>
 		    <p>You can <strong>select cells to highlight them</strong> as you think, discuss, and challenge assumptions. You can <strong>click multiple times to progress through colors</strong> indicating a neutral, weak, warning, and good status.</p>
-		    <p><em>Inspired by and adapted from <a href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley.</em></p>
+		    <p><em>Inspired by and adapted from <a href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley as well as <a href="https://medium.com/wardleymaps/better-for-less-58fe8c0a3aaa">Better for less</a>.</em></p>
 		</div>
 		</div>
 		</div>
@@ -58,7 +58,7 @@
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
 			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine: Phase 1
+			<span class="caret"></span> Phase 1: Stop self-harm
 			</a>
 		    </h4>
 		</div>
@@ -161,7 +161,7 @@
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
 			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine: Phase 2
+			<span class="caret"></span> Phase 2: Becoming more context aware
 			</a>
 		    </h4>
 		</div>
@@ -264,7 +264,7 @@
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
 			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine: Phase 3
+			<span class="caret"></span> Phase 3: Better for less
 			</a>
 		    </h4>
 		</div>
@@ -367,7 +367,7 @@
 		<div class="panel-heading" role="tab" id="doctrineHeading">
 		    <h4 class="panel-title">
 			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine: Phase 4
+			<span class="caret"></span> Phase 4: Continuously evolving
 			</a>
 		    </h4>
 		</div>

--- a/doctrine.html
+++ b/doctrine.html
@@ -75,28 +75,28 @@
 			    <tbody>
 				<tr>
 				  <td class="heading">Communication</td>
-				  <td>Use a common language <em>(necessary for collaboration)</em></td>
-				  <td>Challenge assumptions <em>(speak up and question)</em></td>
-				  <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				  <td data-toggle="tooltip" title="A necessity for effective collaboration is a common language. Maps allow many people with different aptitudes (e.g. marketing, operations, finance and IT) to work together in order to create a common understanding. Collaboration without a common language is just noise before failure.">Use a common language <em>(necessary for collaboration)</em></td>
+				  <td data-toggle="tooltip" title="Maps allow for assumptions to be visually exposed. You should encourage challenge to any map with a focus on creating a better map and a better understanding. Don’t be afraid of challenge, there is no place for ego if you want to learn.">Challenge assumptions <em>(speak up and question)</em></td>
+				  <td data-toggle="tooltip" title="There is a reasonably strong correlation between awareness and performance, so focus on this. Try to understand the landscape that you are competing in and understand any proposals in terms of this. Look before you leap.">Focus on high situational awareness <em>(understand what is being considered)</em></td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Remove bias and duplication</td>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td data-toggle="tooltip" title="When mapping a landscape then know who your users are e.g. customers, shareholders, regulators and staff.">Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td data-toggle="tooltip" title="An essential part of mapping is the anchor of user needs. Ideally you want to create an environment where your needs are achieved by meeting the needs of your users. Be mindful that these needs will evolve due to competition and in the uncharted space they are uncertain. Also, be aware that users may have different and competing needs and be prepared to balance the conflict.">Focus on user needs</td>
+				    <td data-toggle="tooltip" title="Use multiple maps to help you remove duplication and bias within an organisation. You will often find in any large organisation that there are people custom building what is a commodity or rebuilding something that exists elsewhere. Remember, that they’re not doing this because they’re daft but because of pre-existing inertia or the lack of any effective communication mechanism i.e. they simply don’t know it exists elsewhere. Be warned, the level of duplication within most organisations vastly exceeds any expectations that they might have and you’re often treading on the toes of someone’s pet project. Large distributed companies often talk about duplication in the single digits e.g. we have six enterprise content management systems. They tend to react in horror when it is “discovered” that they have hundreds or even “thousands”. People can get very defensive in this space and want to shut you down.">Remove bias and duplication</td>
+				    <td data-toggle="tooltip" title="Try to avoid the tyranny of one. Understand that there is no magic solution and that you have to use multiple methods (e.g. agile or lean or six sigma) as appropriate. In any large system, multiple methods may be used at the same time. Be mindful of ego here, tribes can form with almost religious fervour about the righteousness of their method. Have fortitude, you’ll often find you’re arguing against all these tribes at the same time.">Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
 				</tr>
 				<tr>
 				  <td class="heading">Operation</td>
-				  <td>Think small <em>(as in know the details)</em></td>
+				  <td data-toggle="tooltip" title="Know the details, use small teams and break large landscapes into small contracts. Don’t be chased away by fears of complexity of management.">Think small <em>(as in know the details)</em></td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				  <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				  <td data-toggle="tooltip" title="The purpose of mapping is not just to create a map and a shared understanding but also to learn climatic patterns, doctrine and context specific play. Maps provide a systematic way of doing this as long as you collate, review and learn from them. Have a bias towards such learning and the use of data.">Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
@@ -127,49 +127,49 @@
 			    <tbody>
 				<tr>
 				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
+				    <td data-toggle="tooltip" title="Have a bias towards openness within your organisation. If you want to effectively learn about the landscape then you need to share your maps with others and allow them to add their wisdom and their challenge to the process. Building maps in secret in your organisations is a surefire way of having a future meeting where somebody points out the blindingly obvious thing you have missed.">Be transparent <em>(a bias towards open)</em></td>
 				    <td></td>
 				    <td></td>
 				    <td></td>
 				</tr>
 				<tr>
 				  <td class="heading" rowspan="2">Development</td>
-				  <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				  <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
-				  <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				  <td data-toggle="tooltip" title="Try to focus on the outcome and what you’re trying to achieve. Realise that different types of contract will be needed e.g. outsourced or time and material based or worth based development. Along with a focus on outcomes, try and keep contracts constrained in terms of time and budget.">Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				  <td data-toggle="tooltip" title="There will always be edge cases or a way to make something more perfect but if what you’re building could use a component that already exists then try to avoid the urge to re-invent it. If you’re a taxi company then investing your funds into making that perfect tyre will not help your business. Always challenge when you depart from using something that already exists. The old adage of “It doesn’t matter if the cat is black or white as long as it catches mice” is relevant here.">Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				  <td data-toggle="tooltip" title="You’ll likely to use other tools alongside mapping when scenario planning and examining the viability of different points of attack. This can include financial models to my current favourite of business model canvas.">Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td data-toggle="tooltip" title="Break large systems down into small components, use and re-use inexpensive components where possible, constrain budgets and time, build as simply and as elegantly as possible.">Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
 				</tr>
 				<tr>
-				  <td>Use standards where appropriate</td>
+				  <td data-toggle="tooltip" title="If something is industrialised and if standards exist then try to use them. There’s always a temptation to build a better standard but avoid this or building abstraction layers on top of other “standards” unless you have an extremely compelling reason to do so. If you need a toaster, buy a toaster and don’t try building one from scratch.">Use standards where appropriate</td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Operation</td>
-				  <td>Manage failure</td>
-				  <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				  <td>Effectiveness over efficiency</td>
+				  <td data-toggle="tooltip" title="In any system there is risk. Use the maps where possible to help you understand failure modes, what can go wrong and what will be impacted if a component fails. Try where possible to mitigate risks by distributing systems, by designing for failure and by the constant introduction of failure (use of chaos engines such as Netflix’s chaos monkey). Avoid known failure modes such as building large scale (death star) like efforts.">Manage failure</td>
+				  <td data-toggle="tooltip" title="At some point you will face inertia to change e.g. existing practice, political capital or previous investment. Try and understand the root cause. Ideally use a map to anticipate this before you encounter it and hence have prepared solutions & counter arguments. If possible, use the maps to enable people to discover their own inertia.">Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				  <td data-toggle="tooltip" title="Whilst optimising flow is important, be careful not to waste valuable time making the ineffective more efficient. Understand the landscape and how it is changing before you attempt to optimise flow.">Effectiveness over efficiency</td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Structure</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
+				    <td data-toggle="tooltip" title="Know the details, use small teams and break large landscapes into small contracts. Don’t be chased away by fears of complexity of management.">Think small <em>(as in teams, "two pizza")</em></td>
+				    <td data-toggle="tooltip" title="Have a bias towards distributing power from the centre including yourself. Put power in the hands of those who are closest to the choices that need to be made.">Distribute power and decision making</td>
+				    <td data-toggle="tooltip" title="Understand that people not only have aptitudes (e.g. finance, engineering, operations and marketing) but different attitudes (pioneer, settler and town planner). The mindsets are different.">Think aptitude and attitude</td>
 				    <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				  <td>A bias towards action <em>(learn by playing the game)</em></td>
+				  <td data-toggle="tooltip" title="Do not attempt to create the perfect map. Have a bias towards action because the landscape will change and you will discover more through action. You learn by playing the game.">A bias towards action <em>(learn by playing the game)</em></td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Leading</td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				    <td data-toggle="tooltip" title="The speed at which you move around the cycle is important. There is little point implementing FIRE like principles in developing a system if it takes you a year to make decision to act. An imperfect plan executed today is better than a perfect plan executed tomorrow.">Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td data-toggle="tooltip" title="Understand that strategy is iterative. You need to adapt in fast cycles according to the changing environment. The best you can hope for is a direction, a constant process of learning and improvement of your gameplay along the way.">Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
 				    <td></td>
 				    <td></td>
 				</tr>
@@ -199,27 +199,27 @@
 			    <tbody>
 				<tr>
 				  <td class="heading">Operation</td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td data-toggle="tooltip" title="Within a map there will be many flows of capital — whether information, risk, social or financial. Try to optimise this and remove bottlenecks.">Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td data-toggle="tooltip" title="Have a bias towards continual improvement.">Do better with less <em>(continual improvement)</em></td>
+				    <td data-toggle="tooltip" title="Don’t settle for as good as or slightly better than competitors. Always strive for the very best that can be achieved.">Set exceptional standards <em>(great is just not good enough)</em></td>
 				    <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Seek the best</td>
+				    <td data-toggle="tooltip" title="Provide people with purpose (including a moral imperative and a scope) for action. Enable them to build mastery in their chosen area and give them the freedom (& autonomy) to act.">Provide purpose, mastery, & autonomy</td>
+				    <td data-toggle="tooltip" title="Try to find and grow the best people with the best aptitude and attitude for their roles. Invest in keeping them. Don’t force them into becoming something they’re not. It’s perfectly reasonable for a truly gifted systems tester who excels in a town planning world of massively complicated and automated systems to be paid more than the project manager. What you want to avoid is taking exceptional people out of their role and putting them into something they are not suited to simply because they think that is the only way to progress. Leadership, management and engineering are all aptitudes, they are all valuable and they have to work in concert. If the hierarchy of your organisation uniformly reflects your pay scales then you’re likely to be draining talent from where it should be and putting it into roles that it is not suited for. This is often done for arguments of “responsibility” or “managing bigger teams” (which also causes people to try and accumulate empires) or “spreading experience” or “career path” but there are alternative ways of achieving this. Taking a gifted engineer and turning them into a mediocre project manager is not wise. This is probably one of the most difficult areas as ego is quickly encountered.">Seek the best</td>
 				    <td></td>
 				    <td></td>
 				</tr>
 				<tr>
 				    <td class="heading" rowspan="2">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td data-toggle="tooltip" title="Take responsibility for your environment, your actions within it and how you play the game. You could outsource this to a third party in the way a chess player could outsource their gameplay to another but you won’t learn and it is still you that loses.">Be the owner <em>(take responsibility)</em></td>
+				    <td data-toggle="tooltip" title="Whilst the actions you take, the way that you organise and the focus on detail requires you to think small when it comes to inspiring others, providing direction and moral imperative then think big. Your purpose is not to defend the narrow pass of Thermopylae but instead to defeat the Persian army and save the Greek states.">Think big <em>(inspire others, provide direction)</em></td>
+				    <td data-toggle="tooltip" title="There will be uncertainty, emerging patterns and surprises along the way. That’s the very nature of competition due to the involvement of other actors. Embrace this, don’t fall for the temptation that you can plan the future. What matters is not the plan but the preparation and your ability to adapt.">Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td data-toggle="tooltip" title="Once you’ve set a direction commit to it. There will often be hurdles and obstacles but don’t just simply abandon a direction because a single step is challenging. Try to find paths around the obstacles. If you’re building a system and a common component is not as expected then that can often prove a market opportunity.">Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
 				</tr>
 				<tr>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				    <td data-toggle="tooltip" title="Listen to others, be selfless, have fortitude and be humble. Inspire others by who you are and what you do. There are many ways to manipulate the landscape e.g. with marketing by persuading others that what is a commodity is somehow different or that a product is unique to them. But these manipulations come with a cost not just externally but internally. We can start to believe our own hype, our own infallibility and our “right” to the market. Avoid this arrogance at all costs.">Be humble <em>(listen, be selfless, have fortitude)</em></td>
 				    <td></td>
 				    <td></td>
 				    <td></td>
@@ -250,18 +250,18 @@
 			    <tbody>
 				<tr>
 				  <td class="heading">Structure</td>
-				    <td>Design for constant evolution</td>
-				    <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				    <td data-toggle="tooltip" title="Create an organisational system which copes with the constant ebb and flow in the landscape. Ideally, changes should flow through your organisation without the need for constant restructuring. A cell based structure using a system of theft with pioneers, settlers and town planners is one such system.">Design for constant evolution</td>
+				    <td data-toggle="tooltip" title="Understand that a company which plans for longevity needs to cope with not only the discovery of uncharted components but the use of the industrialised and the transition between these two extremes. You will need different attitudes. You will therefore create many cultures in your organisation e.g. pioneers, settlers and town planners have different cultures. This is not a negative and don’t try to grind everyone into a single bland culture. It will not make them happy.">There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				  <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				  <td data-toggle="tooltip" title="There are many different forms of ecosystems and ways to exploit them. You can build powerful sensing engines (e.g. the ILC model) for future change, sources of co-operation with others, defensive and offensive alliances. But ecosystems need management, they need tending as a gardener tends a garden — sometimes you allow them to grow wild, sometime you harvest, sometimes you help direct or constrain them. These are particular skills that you can develop but most important is the principle — listen to them.">Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Leading</td>
-				  <td>Exploit the landscape</td>
-				  <td>There is no core <em>(everything is transient)</em></td>
+				  <td data-toggle="tooltip" title="Use the landscape to your advantage, there are often powerful force multipliers. You might decide not to take advantage of a competitor or a change in the market but that should be a conscious choice.">Exploit the landscape</td>
+				  <td data-toggle="tooltip" title="Everything is transient, whatever you think is core to your company won’t be at some point in the future. The only things that are truly static are dead.">There is no core <em>(everything is transient)</em></td>
 				</tr>
 			    </tbody>
 			</table>
@@ -290,78 +290,78 @@
 			    <tbody>
 				<tr>
 				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				    <td data-toggle="tooltip" title="">Be transparent <em>(a bias towards open)</em></td>
+				    <td data-toggle="tooltip" title="There is a reasonably strong correlation between awareness and performance, so focus on this. Try to understand the landscape that you are competing in and understand any proposals in terms of this. Look before you leap.">Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				    <td data-toggle="tooltip" title="A necessity for effective collaboration is a common language. Maps allow many people with different aptitudes (e.g. marketing, operations, finance and IT) to work together in order to create a common understanding. Collaboration without a common language is just noise before failure.">Use a common language <em>(necessary for collaboration)</em></td>
+				    <td data-toggle="tooltip" title="Maps allow for assumptions to be visually exposed. You should encourage challenge to any map with a focus on creating a better map and a better understanding. Don’t be afraid of challenge, there is no place for ego if you want to learn.">Challenge assumptions <em>(speak up and question)</em></td>
 				</tr>
 				<tr>
 				    <td class="heading" rowspan="3">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
-				    <td>Remove bias and duplication</td>
+				    <td data-toggle="tooltip" title="When mapping a landscape then know who your users are e.g. customers, shareholders, regulators and staff.">Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
+				    <td data-toggle="tooltip" title="An essential part of mapping is the anchor of user needs. Ideally you want to create an environment where your needs are achieved by meeting the needs of your users. Be mindful that these needs will evolve due to competition and in the uncharted space they are uncertain. Also, be aware that users may have different and competing needs and be prepared to balance the conflict.">Focus on user needs</td>
+				    <td data-toggle="tooltip" title="">Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
+				    <td data-toggle="tooltip" title="Use multiple maps to help you remove duplication and bias within an organisation. You will often find in any large organisation that there are people custom building what is a commodity or rebuilding something that exists elsewhere. Remember, that they’re not doing this because they’re daft but because of pre-existing inertia or the lack of any effective communication mechanism i.e. they simply don’t know it exists elsewhere. Be warned, the level of duplication within most organisations vastly exceeds any expectations that they might have and you’re often treading on the toes of someone’s pet project. Large distributed companies often talk about duplication in the single digits e.g. we have six enterprise content management systems. They tend to react in horror when it is “discovered” that they have hundreds or even “thousands”. People can get very defensive in this space and want to shut you down.">Remove bias and duplication</td>
 				</tr>
 				<tr>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
+				    <td data-toggle="tooltip" title="Try to avoid the tyranny of one. Understand that there is no magic solution and that you have to use multiple methods (e.g. agile or lean or six sigma) as appropriate. In any large system, multiple methods may be used at the same time. Be mindful of ego here, tribes can form with almost religious fervour about the righteousness of their method. Have fortitude, you’ll often find you’re arguing against all these tribes at the same time.">Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
+				    <td data-toggle="tooltip" title="Try to focus on the outcome and what you’re trying to achieve. Realise that different types of contract will be needed e.g. outsourced or time and material based or worth based development. Along with a focus on outcomes, try and keep contracts constrained in terms of time and budget.">Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
+				    <td data-toggle="tooltip" title="There will always be edge cases or a way to make something more perfect but if what you’re building could use a component that already exists then try to avoid the urge to re-invent it. If you’re a taxi company then investing your funds into making that perfect tyre will not help your business. Always challenge when you depart from using something that already exists. The old adage of “It doesn’t matter if the cat is black or white as long as it catches mice” is relevant here.">Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
+				    <td data-toggle="tooltip" title="If something is industrialised and if standards exist then try to use them. There’s always a temptation to build a better standard but avoid this or building abstraction layers on top of other “standards” unless you have an extremely compelling reason to do so. If you need a toaster, buy a toaster and don’t try building one from scratch.">Use standards where appropriate</td>
 				</tr>
 				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td data-toggle="tooltip" title="Try to avoid the tyranny of one. Understand that there is no magic solution and that you have to use multiple methods (e.g. agile or lean or six sigma) as appropriate. In any large system, multiple methods may be used at the same time. Be mindful of ego here, tribes can form with almost religious fervour about the righteousness of their method. Have fortitude, you’ll often find you’re arguing against all these tribes at the same time.">Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
 				</tr>
 				<tr>
 				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
+				    <td data-toggle="tooltip" title="At some point you will face inertia to change e.g. existing practice, political capital or previous investment. Try and understand the root cause. Ideally use a map to anticipate this before you encounter it and hence have prepared solutions & counter arguments. If possible, use the maps to enable people to discover their own inertia.">Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
+				    <td data-toggle="tooltip" title="Within a map there will be many flows of capital — whether information, risk, social or financial. Try to optimise this and remove bottlenecks.">Optimise flow <em>(remove bottlenecks)</em></td>
+				    <td data-toggle="tooltip" title="Know the details, use small teams and break large landscapes into small contracts. Don’t be chased away by fears of complexity of management.">Think small <em>(as in know the details)</em></td>
+				    <td data-toggle="tooltip" title="Whilst optimising flow is important, be careful not to waste valuable time making the ineffective more efficient. Understand the landscape and how it is changing before you attempt to optimise flow.">Effectiveness over efficiency</td>
 				</tr>
 				<tr>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
+				    <td data-toggle="tooltip" title="Have a bias towards continual improvement.">Do better with less <em>(continual improvement)</em></td>
+				    <td data-toggle="tooltip" title="Don’t settle for as good as or slightly better than competitors. Always strive for the very best that can be achieved.">Set exceptional standards <em>(great is just not good enough)</em></td>
+				    <td data-toggle="tooltip" title="In any system there is risk. Use the maps where possible to help you understand failure modes, what can go wrong and what will be impacted if a component fails. Try where possible to mitigate risks by distributing systems, by designing for failure and by the constant introduction of failure (use of chaos engines such as Netflix’s chaos monkey). Avoid known failure modes such as building large scale (death star) like efforts.">Manage failure</td>
 				    <td></td>
 				</tr>
 				<tr>
 				    <td class="heading" rowspan="2">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
+				    <td data-toggle="tooltip" title="Provide people with purpose (including a moral imperative and a scope) for action. Enable them to build mastery in their chosen area and give them the freedom (& autonomy) to act.">Provide purpose, mastery, & autonomy</td>
+				    <td data-toggle="tooltip" title="Know the details, use small teams and break large landscapes into small contracts. Don’t be chased away by fears of complexity of management.">Think small <em>(as in teams, "two pizza")</em></td>
+				    <td data-toggle="tooltip" title="Have a bias towards distributing power from the centre including yourself. Put power in the hands of those who are closest to the choices that need to be made.">Distribute power and decision making</td>
+				    <td data-toggle="tooltip" title="Understand that people not only have aptitudes (e.g. finance, engineering, operations and marketing) but different attitudes (pioneer, settler and town planner). The mindsets are different.">Think aptitude and attitude</td>
 				</tr>
 				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
+				  <td data-toggle="tooltip" title="Create an organisational system which copes with the constant ebb and flow in the landscape. Ideally, changes should flow through your organisation without the need for constant restructuring. A cell based structure using a system of theft with pioneers, settlers and town planners is one such system.">Design for constant evolution</td>
+				  <td data-toggle="tooltip" title="Understand that a company which plans for longevity needs to cope with not only the discovery of uncharted components but the use of the industrialised and the transition between these two extremes. You will need different attitudes. You will therefore create many cultures in your organisation e.g. pioneers, settlers and town planners have different cultures. This is not a negative and don’t try to grind everyone into a single bland culture. It will not make them happy.">There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
+				  <td data-toggle="tooltip" title="Try to find and grow the best people with the best aptitude and attitude for their roles. Invest in keeping them. Don’t force them into becoming something they’re not. It’s perfectly reasonable for a truly gifted systems tester who excels in a town planning world of massively complicated and automated systems to be paid more than the project manager. What you want to avoid is taking exceptional people out of their role and putting them into something they are not suited to simply because they think that is the only way to progress. Leadership, management and engineering are all aptitudes, they are all valuable and they have to work in concert. If the hierarchy of your organisation uniformly reflects your pay scales then you’re likely to be draining talent from where it should be and putting it into roles that it is not suited for. This is often done for arguments of “responsibility” or “managing bigger teams” (which also causes people to try and accumulate empires) or “spreading experience” or “career path” but there are alternative ways of achieving this. Taking a gifted engineer and turning them into a mediocre project manager is not wise. This is probably one of the most difficult areas as ego is quickly encountered.">Seek the best</td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
+				    <td data-toggle="tooltip" title="The purpose of mapping is not just to create a map and a shared understanding but also to learn climatic patterns, doctrine and context specific play. Maps provide a systematic way of doing this as long as you collate, review and learn from them. Have a bias towards such learning and the use of data.">Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
+				    <td data-toggle="tooltip" title="Do not attempt to create the perfect map. Have a bias towards action because the landscape will change and you will discover more through action. You learn by playing the game.">A bias towards action <em>(learn by playing the game)</em></td>
+				    <td data-toggle="tooltip" title="Whatever you do will evolve. So have a bias towards the new, be curious and take appropriate risks. Be willing to experiment.">A bias towards the new <em>(be curious, take appropriate risks)</em></td>
+				    <td data-toggle="tooltip" title="There are many different forms of ecosystems and ways to exploit them. You can build powerful sensing engines (e.g. the ILC model) for future change, sources of co-operation with others, defensive and offensive alliances. But ecosystems need management, they need tending as a gardener tends a garden — sometimes you allow them to grow wild, sometime you harvest, sometimes you help direct or constrain them. These are particular skills that you can develop but most important is the principle — listen to them.">Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
 				</tr>
 				<tr>
 				    <td class="heading" rowspan="3">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
+				    <td data-toggle="tooltip" title="Take responsibility for your environment, your actions within it and how you play the game. You could outsource this to a third party in the way a chess player could outsource their gameplay to another but you won’t learn and it is still you that loses.">Be the owner <em>(take responsibility)</em></td>
+				    <td data-toggle="tooltip" title="The speed at which you move around the cycle is important. There is little point implementing FIRE like principles in developing a system if it takes you a year to make decision to act. An imperfect plan executed today is better than a perfect plan executed tomorrow.">Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
+				    <td data-toggle="tooltip" title="Whilst the actions you take, the way that you organise and the focus on detail requires you to think small when it comes to inspiring others, providing direction and moral imperative then think big. Your purpose is not to defend the narrow pass of Thermopylae but instead to defeat the Persian army and save the Greek states.">Think big <em>(inspire others, provide direction)</em></td>
+				    <td data-toggle="tooltip" title="Understand that strategy is iterative. You need to adapt in fast cycles according to the changing environment. The best you can hope for is a direction, a constant process of learning and improvement of your gameplay along the way.">Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
 				</tr>
 				<tr>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
+				    <td data-toggle="tooltip" title="There will be uncertainty, emerging patterns and surprises along the way. That’s the very nature of competition due to the involvement of other actors. Embrace this, don’t fall for the temptation that you can plan the future. What matters is not the plan but the preparation and your ability to adapt.">Strategy is complex <em>(there will be uncertainty)</em></td>
+				    <td data-toggle="tooltip" title="Once you’ve set a direction commit to it. There will often be hurdles and obstacles but don’t just simply abandon a direction because a single step is challenging. Try to find paths around the obstacles. If you’re building a system and a common component is not as expected then that can often prove a market opportunity.">Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
+				    <td data-toggle="tooltip" title="Everything is transient, whatever you think is core to your company won’t be at some point in the future. The only things that are truly static are dead.">There is no core <em>(everything is transient)</em></td>
+				    <td data-toggle="tooltip" title="Listen to others, be selfless, have fortitude and be humble. Inspire others by who you are and what you do. There are many ways to manipulate the landscape e.g. with marketing by persuading others that what is a commodity is somehow different or that a product is unique to them. But these manipulations come with a cost not just externally but internally. We can start to believe our own hype, our own infallibility and our “right” to the market. Avoid this arrogance at all costs.">Be humble <em>(listen, be selfless, have fortitude)</em></td>
 				</tr>
 				<tr>
-				  <td>Exploit the landscape</td>
+				  <td data-toggle="tooltip" title="Use the landscape to your advantage, there are often powerful force multipliers. You might decide not to take advantage of a competitor or a change in the market but that should be a conscious choice.">Exploit the landscape</td>
 				  <td></td>
 				  <td></td>
 				  <td></td>

--- a/doctrine.html
+++ b/doctrine.html
@@ -63,9 +63,8 @@
 		    </h4>
 		</div>
 		<div id="collapsePhaseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
-		    <div class="panel-body">
-		      <p class="lead">What doctrine does your organization make use of?</p>
-		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+		  <div class="panel-body">
+		    <p>The focus in this first phase is simply awareness and removal of duplication. The aim is not to radically change the environment but to stop further damage being caused. Hence the emphasis is on understanding your user needs, improving situational awareness, removing duplication, challenging assumptions, getting to understand the details of what is done and introducing a systematic mechanism of learning — such as the use of maps with a group such as spend control.</p>
 			<table class="table table-hover table-responsive table-rotated-markable">
 			    <thead>
 				<tr>
@@ -75,79 +74,29 @@
 			    </thead>
 			    <tbody>
 				<tr>
-				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				  <td class="heading">Communication</td>
+				  <td>Use a common language <em>(necessary for collaboration)</em></td>
+				  <td>Challenge assumptions <em>(speak up and question)</em></td>
+				  <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
+				  <td></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="3">Development</td>
+				  <td class="heading">Development</td>
 				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
 				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
 				    <td>Remove bias and duplication</td>
-				</tr>
-				<tr>
 				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
 				</tr>
 				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
+				  <td class="heading">Operation</td>
+				  <td>Think small <em>(as in know the details)</em></td>
 				  <td></td>
 				  <td></td>
-				  <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
-				</tr>
-				<tr>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
-				    <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
-				</tr>
-				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
 				  <td></td>
 				</tr>
 				<tr>
 				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
-				</tr>
-				<tr>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
-				</tr>
-				<tr>
-				  <td>Exploit the landscape</td>
+				  <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
 				  <td></td>
 				  <td></td>
 				  <td></td>
@@ -167,8 +116,7 @@
 		</div>
 		<div id="collapsePhaseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
 		    <div class="panel-body">
-		      <p class="lead">What doctrine does your organization make use of?</p>
-		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+		      <p>While phase I is about stopping the rot, phase II builds upon this by helping us to start considering and using the context. Hence the emphasis is on using appropriate tools and methods, thinking about FIRE, managing inertia, having a bias towards action, moving quickly, being transparent about what we do, distributing power and understanding that strategy is an iterative process.</p>
 			<table class="table table-hover table-responsive table-rotated-markable">
 			    <thead>
 				<tr>
@@ -269,9 +217,8 @@
 		    </h4>
 		</div>
 		<div id="collapsePhaseThree" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
-		    <div class="panel-body">
-		      <p class="lead">What doctrine does your organization make use of?</p>
-		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+		  <div class="panel-body">
+		    <p>In this phase, we’re focusing on constant improvement which means optimising flows in the system, seeking the best, a bias towards the new, thinking big, inspiring others, committing to the path, accepting uncertainty, taking responsibility and providing purpose, master & autonomy. This is the phase which is most about change and moving in a better direction whereas the previous phases are about housekeeping.</p>
 			<table class="table table-hover table-responsive table-rotated-markable">
 			    <thead>
 				<tr>
@@ -372,9 +319,8 @@
 		    </h4>
 		</div>
 		<div id="collapsePhaseFour" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
-		    <div class="panel-body">
-		      <p class="lead">What doctrine does your organization make use of?</p>
-		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
+		  <div class="panel-body">
+		    <p>The final phase is focused on creating an environment that copes with constant shocks and changes. This is the point where strategic play comes to the fore and where we design with pioneers, settlers and town planners. The emphasis is on constant evolution, use of multiple cultures, listening to outside ecosystems, understanding that everything is transient and exploiting the landscape.</p>
 			<table class="table table-hover table-responsive table-rotated-markable">
 			    <thead>
 				<tr>

--- a/index.html
+++ b/index.html
@@ -53,536 +53,432 @@
 		</div>
 		</div>
 		</div>
-            <div class="panel panel-default">
-                <div class="panel-heading" role="tab" id="headingIntroductionComponent">
-                <h4 class="panel-title">
-                    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionComponent" aria-expanded="true" aria-controls="collapseIntroduction">
-                    <span class="caret"></span> Introduction: What is a Component?
-                    </a>
-                </h4>
-                </div>
-                <div id="collapseIntroductionComponent" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionComponent">
-                <div class="panel-body">
-                    <p class="lead">A component may be an <strong>Activity</strong>, a <strong>Practice</strong>, <strong>Data</strong>, or <strong>Knowledge</strong>.</p>
-                    <p>For example, a <strong>Cup of Tea</strong> could be a component. It might need additional underlying components such as <strong>Tea</strong> and <strong>Hot Water</strong>. In your organization, a component might be something like a <strong>Web Site</strong>, a <strong>Purchasing Order</strong>, <strong>Adjudication</strong>, or <strong>Feedback Collection</strong>.</p>
-                </div>
-                </div>
-            </div>
-            <div class="panel panel-default">
-                <div class="panel-heading" role="tab" id="headingIntroductionEvolution">
-                <h4 class="panel-title">
-                    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionEvolution" aria-expanded="true" aria-controls="collapseIntroduction">
-                    <span class="caret"></span> Introduction: What is Evolution?
-                    </a>
-                </h4>
-                </div>
-                <div id="collapseIntroductionEvolution" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionEvolution">
-                <div class="panel-body">
-                    <p class="lead">All components <strong>evolve from left to right</strong> under the influence of supply and demand competition.</p>
-                    <table class="table table-responsive">
-                        <thead>
-                            <tr>
-                                <th>Stage of Evolution</th>
-                                <th><h3>I</h3></th>
-                                <th><h3>II</h3></th>
-                                <th><h3>III</h3></th>
-                                <th><h3>IV</h3></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td class="heading heading-parent"></td>
-                                <td colspan="4">
-                                    <svg class="svg-hidden">
-                                        <defs>
-                                            <symbol id="arrow-right" viewBox="0 0 64 64" preserveAspectRatio="none">
-                                                <title>arrow-right</title>
-                                                <path d="M62 32l-2-30v18h-62v24h62v18z"></path>
-                                            </symbol>
-                                        </defs>
-                                    </svg>
-                                    <svg class="arrow-right"><use href="#arrow-right"></use></svg>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td class="heading"></td>
-                                <td class="bg-danger">
-                                    <h3>Genesis</h3>
-                                    <p>Unique, rare, uncertain, constantly changing, newly-discovered.</p>
-                                    <p>The focus is on <strong>exploring</strong>.</p>
-                                </td>
-                                <td class="bg-warning">
-                                    <h3>Custom</h3>
-                                    <p>Uncommon, frequently-changing, requires artisanal skill, no two are the same.</p>
-                                    <p>The focus is on <strong>learning</strong> and <strong>developing the craft</strong></p>
-                                </td>
-                                <td class="bg-success">
-                                    <h3>Product (and rental)</h3>
-                                    <p>Increasingly common, more defined, better understood. Repeatable processes. Change is slower. Initial differentiation but increasing stability and sameness. There are often many of the same kind of product.</p>
-                                    <p>The focus is on <strong>refining</strong> and <strong>improving</strong>.</p>
-                                </td>
-                                <td class="bg-info">
-                                    <h3>Commodity (and utility)</h3>
-                                    <p>Scale and volume operations of production. Highly standardized. Defined. Fixed. Undifferentiated. Fit for a specific known purpose. Repetition, repetition, repetition... With time, it becomes commonplace and less visible.</p>
-                                    <p>The focus is on <strong>ruthlessly removing deviation</strong>, <strong>industrialising</strong>, and <strong>increasing operational efficiency</strong>.
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                </div>
-            </div>
-            <div class="panel panel-default">
-                <div class="panel-heading" role="tab" id="headingIntroductionEvolutionaryCharacteristics">
-                <h4 class="panel-title">
-                    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionEvolutionaryCharacteristics" aria-expanded="true" aria-controls="collapseIntroduction">
-                    <span class="caret"></span> Introduction: Evolutionary Characteristics
-                    </a>
-                </h4>
-                </div>
-                <div id="collapseIntroductionEvolutionaryCharacteristics" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionEvolutionaryCharacteristics">
-                <div class="panel-body">
-                    <p class="lead">As components evolve, <strong>their characteristics change</strong>.</p>
-                    <table class="table table-hover table-responsive">
-                        <thead>
-                            <tr>
-                                <th><h3>I</h3></th>
-                                <th><h3>II</h3></th>
-                                <th><h3>III</h3></th>
-                                <th><h3>IV</h3></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td class="bg-danger"><h3>Genesis</h3></td>
-                                <td class="bg-warning"><h3>Custom</h3></td>
-                                <td class="bg-success"><h3>Product (+rental)</h3></td>
-                                <td class="bg-info"><h3>Commodity (+utility)</h3></td>
-                            </tr>
-                            <tr>
-                                <td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
-                            </tr>
-                            <tr>
-                                <td colspan="2"><strong>Uncharted</strong></td>
-                                <td colspan="2" class="text-right"><strong>Industrialised</strong></td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Chaotic</td>
-                                <td colspan="2" class="text-right">Ordered</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Uncertain</td>
-                                <td colspan="2" class="text-right">Known</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Unpredictable</td>
-                                <td colspan="2" class="text-right">Measured</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Changing</td>
-                                <td colspan="2" class="text-right">Stable</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Different</td>
-                                <td colspan="2" class="text-right">Standard</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Exciting</td>
-                                <td colspan="2" class="text-right">Obvious</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Future Worth</td>
-                                <td colspan="2" class="text-right">Low Margin</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Unusual</td>
-                                <td colspan="2" class="text-right">Essential</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Rare</td>
-                                <td colspan="2" class="text-right">Ubiquitous</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Poorly Understood</td>
-                                <td colspan="2" class="text-right">Defined</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Experimentation</td>
-                                <td colspan="2" class="text-right">Volume Operations</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Differential</td>
-                                <td colspan="2" class="text-right">Operational Efficiency</td>
-                            </tr>
-                            <tr>
-                                <td colspan="2">Competitive Advantage</td>
-                                <td colspan="2" class="text-right">Cost of Doing Business</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                </div>
-            </div>
-            <div class="panel panel-default">
-                <div class="panel-heading" role="tab" id="simpleHeading">
-                    <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSimple" aria-expanded="true" aria-controls="collapseSimple">
-                        <span class="caret"></span> Evolutionary Characteristics Cheat Sheet: Simple
-                        </a>
-                    </h4>
-                </div>
-                <div id="collapseSimple" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="simpleHeading">
-                    <div class="panel-body">
-                        <p class="lead">How evolved is the component?</p>
-                        <p>Select cells to highlight them as you think, discuss, and challenge assumptions.</p>
-                        <table class="table table-hover table-responsive table-markable">
-                            <thead>
-                                <tr>
-                                    <th>Stage of Evolution</th>
-                                    <th><h3>I</h3></th>
-                                    <th><h3>II</h3></th>
-                                    <th><h3>III</h3></th>
-                                    <th><h3>IV</h3></th>
-                                </tr>
-                                <tr>
-                                    <th class="active"></th>
-                                    <th class="bg-danger"><h3>Genesis</h3></th>
-                                    <th class="bg-warning"><h3>Custom</h3></th>
-                                    <th class="bg-success"><h3>Product (+rental)</h3></th>
-                                    <th class="bg-info"><h3>Commodity (+utility)</h3></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-
-                                <tr>
-                                    <td class="heading"></td>
-                                    <td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Ubiquity</td>
-                                    <td>Rare</td>
-                                    <td>Slowly increasing consumption</td>
-                                    <td>Rapidly increasing consumption</td>
-                                    <td>Widespread and stabilising</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Certainty</td>
-                                    <td>Poorly understood</td>
-                                    <td>Rapid increases in learning</td>
-                                    <td>Rapid increases in use / fit for purpose</td>
-                                    <td>Commonly understood (in terms of use)</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Market</td>
-                                    <td>Undefined market</td>
-                                    <td>Forming market</td>
-                                    <td>Growing market</td>
-                                    <td>Mature market</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">User perception</td>
-                                    <td>Different / confusing / exciting / surprising</td>
-                                    <td>Leading edge / emerging</td>
-                                    <td>Common / disappointed if not used or available</td>
-                                    <td>Standard / expected</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Failure</td>
-                                    <td>High / tolerated / assumed</td>
-                                    <td>Moderate / unsurprising but disappointed</td>
-                                    <td>Not tolerated, focus on constant improvement</td>
-                                    <td>Operational efficiency and surprised by failure</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>                 
-            <div class="panel panel-default">
-                <div class="panel-heading" role="tab" id="advancedHeading">
-                    <h4 class="panel-title">
-                        <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseAdvanced" aria-expanded="true" aria-controls="collapseAdvanced">
-                        <span class="caret"></span> Evolutionary Characteristics Cheat Sheet: Advanced
-                        </a>
-                    </h4>
-                </div>
-                <div id="collapseAdvanced" class="panel-collapse collapse" role="tabpanel" aria-labelledby="advancedHeading">
-                    <div class="panel-body">
-                        <p class="lead">How evolved is the component?</p>
-                        <p>Select cells to highlight them as you think, discuss, and challenge assumptions.</p>
-                        <table class="table table-hover table-responsive table-markable">
-                            <thead>
-                                <tr>
-                                    <th>Stage of Evolution</th>
-                                    <th><h3>I</h3></th>
-                                    <th><h3>II</h3></th>
-                                    <th><h3>III</h3></th>
-                                    <th><h3>IV</h3></th>
-                                </tr>
-                                <tr>
-                                    <th class="active"></th>
-                                    <th class="bg-danger"><h3>Genesis</h3></th>
-                                    <th class="bg-warning"><h3>Custom</h3></th>
-                                    <th class="bg-success"><h3>Product (+rental)</h3></th>
-                                    <th class="bg-info"><h3>Commodity (+utility)</h3></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-
-                                <tr>
-                                    <td class="heading heading-parent">Characteristics</td>
-                                    <td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Ubiquity</td>
-                                    <td>Rare</td>
-                                    <td>Slowly increasing consumption</td>
-                                    <td>Rapidly increasing consumption</td>
-                                    <td>Widespread and stabilising</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Certainty</td>
-                                    <td>Poorly understood</td>
-                                    <td>Rapid increases in learning</td>
-                                    <td>Rapid increases in use / fit for purpose</td>
-                                    <td>Commonly understood (in terms of use)</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Publication Types</td>
-                                    <td>Normally describe the wonder of the thing</td>
-                                    <td>Build / construct / awareness and learning</td>
-                                    <td>Maintenance / operations / installation / features</td>
-                                    <td>Focused on use</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading heading-parent">General Properties</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Market</td>
-                                    <td>Undefined market</td>
-                                    <td>Forming market</td>
-                                    <td>Growing market</td>
-                                    <td>Mature market</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Knowledge management</td>
-                                    <td>Uncertain</td>
-                                    <td>Learning on use</td>
-                                    <td>Learning on operation</td>
-                                    <td>Known / accepted</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Market perception</td>
-                                    <td>Chaotic (non-linear)</td>
-                                    <td>Domain of experts</td>
-                                    <td>Increasing expectations of use</td>
-                                    <td>Ordered (appearance of being linear) / trivial</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">User perception</td>
-                                    <td>Different / confusing / exciting / surprising</td>
-                                    <td>Leading edge / emerging</td>
-                                    <td>Common / disappointed if not used or available</td>
-                                    <td>Standard / expected</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Perception in industry</td>
-                                    <td>Competitive advantage / unpredictable / unknown</td>
-                                    <td>Competitive advantage / ROI / case examples</td>
-                                    <td>Advantage through implementation / features</td>
-                                    <td>Cost of doing business / accepted</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Focus of value</td>
-                                    <td>High future worth</td>
-                                    <td>Seeking profit / ROI?</td>
-                                    <td>High profitability</td>
-                                    <td>High volume / reducing margin</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Understanding</td>
-                                    <td>Poorly understood / unpredictable</td>
-                                    <td>Increasing understanding / development of measures</td>
-                                    <td>Increasing education / constant refinement of needs / measures</td>
-                                    <td>Believed to be well defined / stable / measurable</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Comparison</td>
-                                    <td>Constantly changing / a differential / unstable</td>
-                                    <td>Learning from others / testing the water / some evidential support</td>
-                                    <td>Feature difference</td>
-                                    <td>Essential / operational advantage</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Failure</td>
-                                    <td>High / tolerated / assumed</td>
-                                    <td>Moderate / unsurprising but disappointed</td>
-                                    <td>Not tolerated, focus on constant improvement</td>
-                                    <td>Operational efficiency and surprised by failure</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Market action</td>
-                                    <td>Gambling / driven by gut</td>
-                                    <td>Exploring a "found" value</td>
-                                    <td>Market analysis / listening to customers</td>
-                                    <td>Metric driven / build what is needed</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Efficiency</td>
-                                    <td>Reducing the cost of change (experimentation)</td>
-                                    <td>Reducing cost of waste (Learning)</td>
-                                    <td>Reducing cost of waste (Learning)</td>
-                                    <td>Reducing cost of deviation (Volume)</td>
-                                </tr>
-                                <tr>
-                                    <td class="heading">Decision drivers</td>
-                                    <td>Heritage / culture</td>
-                                    <td>Analysis & synthesis</td>
-                                    <td>Analysis & synthesis</td>
-                                    <td>Previous experience</td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                </div>
-            </div>                    
 	    <div class="panel panel-default">
-		<div class="panel-heading" role="tab" id="doctrineHeading">
+		<div class="panel-heading" role="tab" id="headingIntroductionComponent">
+		<h4 class="panel-title">
+		    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionComponent" aria-expanded="true" aria-controls="collapseIntroduction">
+		    <span class="caret"></span> Introduction: What is a Component?
+		    </a>
+		</h4>
+		</div>
+		<div id="collapseIntroductionComponent" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionComponent">
+		<div class="panel-body">
+		    <p class="lead">A component may be an <strong>Activity</strong>, a <strong>Practice</strong>, <strong>Data</strong>, or <strong>Knowledge</strong>.</p>
+		    <p>For example, a <strong>Cup of Tea</strong> could be a component. It might need additional underlying components such as <strong>Tea</strong> and <strong>Hot Water</strong>. In your organization, a component might be something like a <strong>Web Site</strong>, a <strong>Purchasing Order</strong>, <strong>Adjudication</strong>, or <strong>Feedback Collection</strong>.</p>
+		</div>
+		</div>
+	    </div>
+	    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="headingIntroductionEvolution">
+		<h4 class="panel-title">
+		    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionEvolution" aria-expanded="true" aria-controls="collapseIntroduction">
+		    <span class="caret"></span> Introduction: What is Evolution?
+		    </a>
+		</h4>
+		</div>
+		<div id="collapseIntroductionEvolution" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionEvolution">
+		<div class="panel-body">
+		    <p class="lead">All components <strong>evolve from left to right</strong> under the influence of supply and demand competition.</p>
+		    <table class="table table-responsive">
+			<thead>
+			    <tr>
+				<th>Stage of Evolution</th>
+				<th><h3>I</h3></th>
+				<th><h3>II</h3></th>
+				<th><h3>III</h3></th>
+				<th><h3>IV</h3></th>
+			    </tr>
+			</thead>
+			<tbody>
+			    <tr>
+				<td class="heading heading-parent"></td>
+				<td colspan="4">
+				    <svg class="svg-hidden">
+					<defs>
+					    <symbol id="arrow-right" viewBox="0 0 64 64" preserveAspectRatio="none">
+						<title>arrow-right</title>
+						<path d="M62 32l-2-30v18h-62v24h62v18z"></path>
+					    </symbol>
+					</defs>
+				    </svg>
+				    <svg class="arrow-right"><use href="#arrow-right"></use></svg>
+				</td>
+			    </tr>
+			    <tr>
+				<td class="heading"></td>
+				<td class="bg-danger">
+				    <h3>Genesis</h3>
+				    <p>Unique, rare, uncertain, constantly changing, newly-discovered.</p>
+				    <p>The focus is on <strong>exploring</strong>.</p>
+				</td>
+				<td class="bg-warning">
+				    <h3>Custom</h3>
+				    <p>Uncommon, frequently-changing, requires artisanal skill, no two are the same.</p>
+				    <p>The focus is on <strong>learning</strong> and <strong>developing the craft</strong></p>
+				</td>
+				<td class="bg-success">
+				    <h3>Product (and rental)</h3>
+				    <p>Increasingly common, more defined, better understood. Repeatable processes. Change is slower. Initial differentiation but increasing stability and sameness. There are often many of the same kind of product.</p>
+				    <p>The focus is on <strong>refining</strong> and <strong>improving</strong>.</p>
+				</td>
+				<td class="bg-info">
+				    <h3>Commodity (and utility)</h3>
+				    <p>Scale and volume operations of production. Highly standardized. Defined. Fixed. Undifferentiated. Fit for a specific known purpose. Repetition, repetition, repetition... With time, it becomes commonplace and less visible.</p>
+				    <p>The focus is on <strong>ruthlessly removing deviation</strong>, <strong>industrialising</strong>, and <strong>increasing operational efficiency</strong>.
+				</td>
+			    </tr>
+			</tbody>
+		    </table>
+		</div>
+		</div>
+	    </div>
+	    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="headingIntroductionEvolutionaryCharacteristics">
+		<h4 class="panel-title">
+		    <a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseIntroductionEvolutionaryCharacteristics" aria-expanded="true" aria-controls="collapseIntroduction">
+		    <span class="caret"></span> Introduction: Evolutionary Characteristics
+		    </a>
+		</h4>
+		</div>
+		<div id="collapseIntroductionEvolutionaryCharacteristics" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingIntroductionEvolutionaryCharacteristics">
+		<div class="panel-body">
+		    <p class="lead">As components evolve, <strong>their characteristics change</strong>.</p>
+		    <table class="table table-hover table-responsive">
+			<thead>
+			    <tr>
+				<th><h3>I</h3></th>
+				<th><h3>II</h3></th>
+				<th><h3>III</h3></th>
+				<th><h3>IV</h3></th>
+			    </tr>
+			</thead>
+			<tbody>
+			    <tr>
+				<td class="bg-danger"><h3>Genesis</h3></td>
+				<td class="bg-warning"><h3>Custom</h3></td>
+				<td class="bg-success"><h3>Product (+rental)</h3></td>
+				<td class="bg-info"><h3>Commodity (+utility)</h3></td>
+			    </tr>
+			    <tr>
+				<td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
+			    </tr>
+			    <tr>
+				<td colspan="2"><strong>Uncharted</strong></td>
+				<td colspan="2" class="text-right"><strong>Industrialised</strong></td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Chaotic</td>
+				<td colspan="2" class="text-right">Ordered</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Uncertain</td>
+				<td colspan="2" class="text-right">Known</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Unpredictable</td>
+				<td colspan="2" class="text-right">Measured</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Changing</td>
+				<td colspan="2" class="text-right">Stable</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Different</td>
+				<td colspan="2" class="text-right">Standard</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Exciting</td>
+				<td colspan="2" class="text-right">Obvious</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Future Worth</td>
+				<td colspan="2" class="text-right">Low Margin</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Unusual</td>
+				<td colspan="2" class="text-right">Essential</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Rare</td>
+				<td colspan="2" class="text-right">Ubiquitous</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Poorly Understood</td>
+				<td colspan="2" class="text-right">Defined</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Experimentation</td>
+				<td colspan="2" class="text-right">Volume Operations</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Differential</td>
+				<td colspan="2" class="text-right">Operational Efficiency</td>
+			    </tr>
+			    <tr>
+				<td colspan="2">Competitive Advantage</td>
+				<td colspan="2" class="text-right">Cost of Doing Business</td>
+			    </tr>
+			</tbody>
+		    </table>
+		</div>
+		</div>
+	    </div>
+	    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="simpleHeading">
 		    <h4 class="panel-title">
-			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseDoctrine" aria-expanded="true" aria-controls="collapseDoctrine">
-			<span class="caret"></span> Doctrine
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseSimple" aria-expanded="true" aria-controls="collapseSimple">
+			<span class="caret"></span> Evolutionary Characteristics Cheat Sheet: Simple
 			</a>
 		    </h4>
 		</div>
-		<div id="collapseDoctrine" class="panel-collapse collapse" role="tabpanel" aria-labelledby="doctrineHeading">
+		<div id="collapseSimple" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="simpleHeading">
 		    <div class="panel-body">
-		      <p class="lead">What doctrine does your organization make use of?</p>
-		      <p>Select cells to highlight them as you think, discuss, and challenge assumptions. In this section, you can click multiple times to progress through colors indicating a neutral, weak, warning, and good status.</p>
-		      <p><em>Inspired by <a  href="https://twitter.com/swardley/status/993517588113186817">this tweetstorm</a> by Simon Wardley.</em></p>
-			<table class="table table-hover table-responsive table-rotated-markable">
+			<p class="lead">How evolved is the component?</p>
+			<p>Select cells to highlight them as you think, discuss, and challenge assumptions.</p>
+			<table class="table table-hover table-responsive table-markable">
 			    <thead>
 				<tr>
-				  <th class="active">Category</th>
-				  <th class="active" colspan="4"><strong>Wardley's Doctrine</strong> (universally useful patterns that a user can apply regardless of context)</th>
+				    <th>Stage of Evolution</th>
+				    <th><h3>I</h3></th>
+				    <th><h3>II</h3></th>
+				    <th><h3>III</h3></th>
+				    <th><h3>IV</h3></th>
+				</tr>
+				<tr>
+				    <th class="active"></th>
+				    <th class="bg-danger"><h3>Genesis</h3></th>
+				    <th class="bg-warning"><h3>Custom</h3></th>
+				    <th class="bg-success"><h3>Product (+rental)</h3></th>
+				    <th class="bg-info"><h3>Commodity (+utility)</h3></th>
 				</tr>
 			    </thead>
 			    <tbody>
+
 				<tr>
-				    <td class="heading">Communication</td>
-				    <td>Be transparent <em>(a bias towards open)</em></td>
-				    <td>Focus on high situational awareness <em>(understand what is being considered)</em></td>
-				    <td>Use a common language <em>(necessary for collaboration)</em></td>
-				    <td>Challenge assumptions <em>(speak up and question)</em></td>
+				    <td class="heading"></td>
+				    <td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="3">Development</td>
-				    <td>Know your users <em>(e.g. customers, shareholders, regulators, staff)</em></td>
-				    <td>Focus on user needs</td>
-				    <td>Think fast, inexpensive, restrained, and elegant (FIRE, formerly FIST)</td>
-				    <td>Remove bias and duplication</td>
+				    <td class="heading">Ubiquity</td>
+				    <td>Rare</td>
+				    <td>Slowly increasing consumption</td>
+				    <td>Rapidly increasing consumption</td>
+				    <td>Widespread and stabilising</td>
 				</tr>
 				<tr>
-				    <td>Use appropriate methods <em>(e.g. agile vs lean vs six sigma)</em></td>
-				    <td>Focus on the outcome not a contract <em>(e.g. worth based development)</em></td>
-				    <td>Be pragmatic <em>(it doesn't matter if the cat is black or white so long as it catches mice)</em></td>
-				    <td>Use standards where appropriate</td>
+				    <td class="heading">Certainty</td>
+				    <td>Poorly understood</td>
+				    <td>Rapid increases in learning</td>
+				    <td>Rapid increases in use / fit for purpose</td>
+				    <td>Commonly understood (in terms of use)</td>
 				</tr>
 				<tr>
-				  <td>Use appropriate tools <em>(e.g. mapping, financial models)</em></td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
+				    <td class="heading">Market</td>
+				    <td>Undefined market</td>
+				    <td>Forming market</td>
+				    <td>Growing market</td>
+				    <td>Mature market</td>
 				</tr>
 				<tr>
-				    <td class="heading" rowspan="2">Operation</td>
-				    <td>Manage inertia <em>(e.g. existing practices, political capital, previous investment)</em></td>
-				    <td>Optimise flow <em>(remove bottlenecks)</em></td>
-				    <td>Think small <em>(as in know the details)</em></td>
-				    <td>Effectiveness over efficiency</td>
+				    <td class="heading">User perception</td>
+				    <td>Different / confusing / exciting / surprising</td>
+				    <td>Leading edge / emerging</td>
+				    <td>Common / disappointed if not used or available</td>
+				    <td>Standard / expected</td>
 				</tr>
 				<tr>
-				    <td>Do better with less <em>(continual improvement)</em></td>
-				    <td>Set exceptional standards <em>(great is just not good enough)</em></td>
-				    <td>Manage failure</td>
-				    <td></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="2">Structure</td>
-				    <td>Provide purpose, mastery, & autonomy</td>
-				    <td>Think small <em>(as in teams, "two pizza")</em></td>
-				    <td>Distribute power and decision making</td>
-				    <td>Think aptitude and attitude</td>
-				</tr>
-				<tr>
-				  <td>Design for constant evolution</td>
-				  <td>There is no one culture <em>(e.g. pioneers, settlers and town planners)</em></td>
-				  <td>Seek the best</td>
-				  <td></td>
-				</tr>
-				<tr>
-				  <td class="heading">Learning</td>
-				    <td>Use a systematic mechanism of learning <em>(a bias towards data)</em></td>
-				    <td>A bias towards action <em>(learn by playing the game)</em></td>
-				    <td>A bias towards the new <em>(be curious, take appropriate risks)</em></td>
-				    <td>Listen to your ecosystems <em>(acts as future sensing engines)</em></td>
-				</tr>
-				<tr>
-				    <td class="heading" rowspan="3">Leading</td>
-				    <td>Be the owner <em>(take responsibility)</em></td>
-				    <td>Move fast <em>(an imperfect plan executed today is better than a perfect plan executed tomorrow)</em></td>
-				    <td>Think big <em>(inspire others, provide direction)</em></td>
-				    <td>Strategy is iterative not linear <em>(fast reactive cycles)</em></td>
-				</tr>
-				<tr>
-				    <td>Strategy is complex <em>(there will be uncertainty)</em></td>
-				    <td>Commit to the direction, be adaptive along the path <em>(crossing the river by feeling the stones)</em></td>
-				    <td>There is no core <em>(everything is transient)</em></td>
-				    <td>Be humble <em>(listen, be selfless, have fortitude)</em></td>
-				</tr>
-				<tr>
-				  <td>Exploit the landscape</td>
-				  <td></td>
-				  <td></td>
-				  <td></td>
+				    <td class="heading">Failure</td>
+				    <td>High / tolerated / assumed</td>
+				    <td>Moderate / unsurprising but disappointed</td>
+				    <td>Not tolerated, focus on constant improvement</td>
+				    <td>Operational efficiency and surprised by failure</td>
 				</tr>
 			    </tbody>
 			</table>
 		    </div>
 		</div>
 	    </div>
-        </div>
+	    <div class="panel panel-default">
+		<div class="panel-heading" role="tab" id="advancedHeading">
+		    <h4 class="panel-title">
+			<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseAdvanced" aria-expanded="true" aria-controls="collapseAdvanced">
+			<span class="caret"></span> Evolutionary Characteristics Cheat Sheet: Advanced
+			</a>
+		    </h4>
+		</div>
+		<div id="collapseAdvanced" class="panel-collapse collapse" role="tabpanel" aria-labelledby="advancedHeading">
+		    <div class="panel-body">
+			<p class="lead">How evolved is the component?</p>
+			<p>Select cells to highlight them as you think, discuss, and challenge assumptions.</p>
+			<table class="table table-hover table-responsive table-markable">
+			    <thead>
+				<tr>
+				    <th>Stage of Evolution</th>
+				    <th><h3>I</h3></th>
+				    <th><h3>II</h3></th>
+				    <th><h3>III</h3></th>
+				    <th><h3>IV</h3></th>
+				</tr>
+				<tr>
+				    <th class="active"></th>
+				    <th class="bg-danger"><h3>Genesis</h3></th>
+				    <th class="bg-warning"><h3>Custom</h3></th>
+				    <th class="bg-success"><h3>Product (+rental)</h3></th>
+				    <th class="bg-info"><h3>Commodity (+utility)</h3></th>
+				</tr>
+			    </thead>
+			    <tbody>
 
-        <p>This work is adapted from <a href="https://medium.com/wardleymaps/finding-a-path-cdb1249078c0" target="_blank">Finding a Path</a> by Simon Wardley, and thereby licensed <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-Share Alike 4.0</a>.</p>
+				<tr>
+				    <td class="heading heading-parent">Characteristics</td>
+				    <td colspan="4"><svg class="arrow-right"><use href="#arrow-right"></use></svg></td>
+				</tr>
+				<tr>
+				    <td class="heading">Ubiquity</td>
+				    <td>Rare</td>
+				    <td>Slowly increasing consumption</td>
+				    <td>Rapidly increasing consumption</td>
+				    <td>Widespread and stabilising</td>
+				</tr>
+				<tr>
+				    <td class="heading">Certainty</td>
+				    <td>Poorly understood</td>
+				    <td>Rapid increases in learning</td>
+				    <td>Rapid increases in use / fit for purpose</td>
+				    <td>Commonly understood (in terms of use)</td>
+				</tr>
+				<tr>
+				    <td class="heading">Publication Types</td>
+				    <td>Normally describe the wonder of the thing</td>
+				    <td>Build / construct / awareness and learning</td>
+				    <td>Maintenance / operations / installation / features</td>
+				    <td>Focused on use</td>
+				</tr>
+				<tr>
+				    <td class="heading heading-parent">General Properties</td>
+				</tr>
+				<tr>
+				    <td class="heading">Market</td>
+				    <td>Undefined market</td>
+				    <td>Forming market</td>
+				    <td>Growing market</td>
+				    <td>Mature market</td>
+				</tr>
+				<tr>
+				    <td class="heading">Knowledge management</td>
+				    <td>Uncertain</td>
+				    <td>Learning on use</td>
+				    <td>Learning on operation</td>
+				    <td>Known / accepted</td>
+				</tr>
+				<tr>
+				    <td class="heading">Market perception</td>
+				    <td>Chaotic (non-linear)</td>
+				    <td>Domain of experts</td>
+				    <td>Increasing expectations of use</td>
+				    <td>Ordered (appearance of being linear) / trivial</td>
+				</tr>
+				<tr>
+				    <td class="heading">User perception</td>
+				    <td>Different / confusing / exciting / surprising</td>
+				    <td>Leading edge / emerging</td>
+				    <td>Common / disappointed if not used or available</td>
+				    <td>Standard / expected</td>
+				</tr>
+				<tr>
+				    <td class="heading">Perception in industry</td>
+				    <td>Competitive advantage / unpredictable / unknown</td>
+				    <td>Competitive advantage / ROI / case examples</td>
+				    <td>Advantage through implementation / features</td>
+				    <td>Cost of doing business / accepted</td>
+				</tr>
+				<tr>
+				    <td class="heading">Focus of value</td>
+				    <td>High future worth</td>
+				    <td>Seeking profit / ROI?</td>
+				    <td>High profitability</td>
+				    <td>High volume / reducing margin</td>
+				</tr>
+				<tr>
+				    <td class="heading">Understanding</td>
+				    <td>Poorly understood / unpredictable</td>
+				    <td>Increasing understanding / development of measures</td>
+				    <td>Increasing education / constant refinement of needs / measures</td>
+				    <td>Believed to be well defined / stable / measurable</td>
+				</tr>
+				<tr>
+				    <td class="heading">Comparison</td>
+				    <td>Constantly changing / a differential / unstable</td>
+				    <td>Learning from others / testing the water / some evidential support</td>
+				    <td>Feature difference</td>
+				    <td>Essential / operational advantage</td>
+				</tr>
+				<tr>
+				    <td class="heading">Failure</td>
+				    <td>High / tolerated / assumed</td>
+				    <td>Moderate / unsurprising but disappointed</td>
+				    <td>Not tolerated, focus on constant improvement</td>
+				    <td>Operational efficiency and surprised by failure</td>
+				</tr>
+				<tr>
+				    <td class="heading">Market action</td>
+				    <td>Gambling / driven by gut</td>
+				    <td>Exploring a "found" value</td>
+				    <td>Market analysis / listening to customers</td>
+				    <td>Metric driven / build what is needed</td>
+				</tr>
+				<tr>
+				    <td class="heading">Efficiency</td>
+				    <td>Reducing the cost of change (experimentation)</td>
+				    <td>Reducing cost of waste (Learning)</td>
+				    <td>Reducing cost of waste (Learning)</td>
+				    <td>Reducing cost of deviation (Volume)</td>
+				</tr>
+				<tr>
+				    <td class="heading">Decision drivers</td>
+				    <td>Heritage / culture</td>
+				    <td>Analysis & synthesis</td>
+				    <td>Analysis & synthesis</td>
+				    <td>Previous experience</td>
+				</tr>
+			    </tbody>
+			</table>
+		    </div>
+		</div>
+	    </div>
+	</div>
 
-        <a href="https://github.com/bemosior/evolutionary-characteristics" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
+	<p>This work is adapted from <a href="https://medium.com/wardleymaps/finding-a-path-cdb1249078c0" target="_blank">Finding a Path</a> by Simon Wardley, and thereby licensed <a href="https://creativecommons.org/licenses/by-sa/4.0/" target="_blank">Creative Commons Attribution-Share Alike 4.0</a>.</p>
+
+	<a href="https://github.com/bemosior/evolutionary-characteristics" target="_blank"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/38ef81f8aca64bb9a64448d0d70f1308ef5341ab/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f6461726b626c75655f3132313632312e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"></a>
     </div>
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="js/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
     <script src="js/bootstrap.min.js" ></script>
     <script>
-        window.onload = function(){
-            $(".table-markable tbody td").on("click", function(e) {
-                if (!$(this).hasClass("heading")) {
-                    $(this).toggleClass("info");
-                }
-            });
-            $(".table-rotated-markable tbody td").on("click", function(e) {
-                if (!$(this).hasClass("heading")) {
-                    if($(this).hasClass("danger")) {
-                        $(this).toggleClass("danger");
-                        $(this).toggleClass("warning");
-                    } else if($(this).hasClass("warning")) {
-                        $(this).toggleClass("warning");
-                        $(this).toggleClass("success");
-                    } else if($(this).hasClass("success")) {
-                        $(this).toggleClass("success");
-                    } else {
-                        $(this).toggleClass("danger");
-                    }
-                }
-            });
-        };
+	window.onload = function(){
+	    $(".table-markable tbody td").on("click", function(e) {
+		if (!$(this).hasClass("heading")) {
+		    $(this).toggleClass("info");
+		}
+	    });
+	    $(".table-rotated-markable tbody td").on("click", function(e) {
+		if (!$(this).hasClass("heading")) {
+		    if($(this).hasClass("danger")) {
+			$(this).toggleClass("danger");
+			$(this).toggleClass("warning");
+		    } else if($(this).hasClass("warning")) {
+			$(this).toggleClass("warning");
+			$(this).toggleClass("success");
+		    } else if($(this).hasClass("success")) {
+			$(this).toggleClass("success");
+		    } else {
+			$(this).toggleClass("danger");
+		    }
+		}
+	    });
+	};
     </script>
 
     <script src="https://widget.flowxo.com/embed.js" data-fxo-widget="eyJ0aGVtZSI6IiNmYTgyMjQiLCJ3ZWIiOnsiYm90SWQiOiI1YWY1OTZiODRhNzc1ODAwODBiZDE2MDUiLCJ0aGVtZSI6IiNmYTgyMjQiLCJsYWJlbCI6IkNvbnZlcnNhdGlvbmFsIFdhcmRsZXkgTWFwcGluZyJ9LCJ3ZWxjb21lVGV4dCI6IkN1cmlvdXMgYWJvdXQgV2FyZGxleSBNYXBwaW5nPyJ9" async defer></script>
@@ -592,7 +488,7 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-    
+
       gtag('config', 'UA-51537292-5');
     </script>
 </body>


### PR DESCRIPTION
Initial commit for #4. This PR:

- Deletes the doctrine section of the main page, index.html
- Adds a doctrine.html with an explanation of doctrine; interactive tables for Simon's four stages; and the original doctrine table from previous versions

This PR does not:
- Have links between index.html and doctrine.html
- Have a new index.html that maps to pages for evolutionary characteristics, doctrine, or other future pages